### PR TITLE
Make things work with new rollup input option and generate returning a promise

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,8 @@ notifications:
 node_js:
   - '6'
   - '4'
-  - '0.12'
 before_install:
-  - npm i -g npm@^2.0.0
+  - npm i -g npm@^5.0.0
 before_script:
   - npm prune
 after_success:

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This plugin requires at least v0.25.4 of rollup. In `rollup.config.js`:
 import multiEntry from 'rollup-plugin-multi-entry';
 
 export default {
-  entry: 'test/**/*.js',
+  input: 'test/**/*.js',
   plugins: [multiEntry()]
 };
 ```
@@ -45,28 +45,28 @@ e.g.
 ```js
 // The usual rollup entry configuration works.
 export default {
-  entry: 'just/one/file.js',
+  input: 'just/one/file.js',
   plugins: [multiEntry()]
   // ...
 };
 
 // As does a glob of files.
 export default {
-  entry: 'a/glob/of/files/**/*.js',
+  input: 'a/glob/of/files/**/*.js',
   plugins: [multiEntry()]
   // ...
 };
 
 // Or an array of files and globs.
 export default {
-  entry: ['an/array.js', 'of/files.js', 'or/globs/**/*.js'],
+  input: ['an/array.js', 'of/files.js', 'or/globs/**/*.js'],
   plugins: [multiEntry()]
   // ...
 };
 
 // For maximum control, arrays of globs to include and exclude.
 export default {
-  entry: {
+  input: {
     include: ['files.js', 'and/globs/**/*.js', 'to/include.js'],
     exclude: ['those/files.js', 'and/globs/*.to.be.excluded.js']
   },
@@ -80,7 +80,7 @@ such cases, use the `exports: false` option like so:
 
 ```js
 export default {
-  entry: 'src/*.js',
+  input: 'src/*.js',
   plugins: [multiEntry({ exports: false })]
 };
 ```

--- a/index.js
+++ b/index.js
@@ -30,11 +30,11 @@ export default function multiEntry(config: ?Config=null) {
   }
 
   return {
-    options(options: { entry: ?string }) {
-      if (options.entry && options.entry !== entry) {
-        configure(options.entry);
+    options(options: { input: ?string }) {
+      if (options.input && options.input !== entry) {
+        configure(options.input);
       }
-      options.entry = entry;
+      options.input = entry;
     },
 
     resolveId(id: string): ?string {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "babelrc-rollup": "^3.0.0",
     "flow-bin": "^0.31.1",
     "mocha": "^3.0.2",
-    "rollup": "^0.34.12",
+    "rollup": "^0.49.2",
     "rollup-plugin-babel": "^2.6.1",
     "semantic-release": "^4.3.5"
   }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "matched": "^0.4.4"
   },
   "devDependencies": {
+    "babel-plugin-external-helpers": "^6.22.0",
     "babel-plugin-transform-flow-strip-types": "^6.14.0",
     "babel-preset-es2015": "^6.14.0",
     "babel-preset-es2015-rollup": "^1.2.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -4,17 +4,17 @@ import babelrc from 'babelrc-rollup';
 var pkg = require('./package.json');
 
 export default {
-  entry: 'index.js',
+  input: 'index.js',
   plugins: [babel(babelrc())],
   external: Object.keys(pkg['dependencies']).concat('path'),
-  targets: [
+  output: [
     {
       format: 'cjs',
-      dest: pkg['main']
+      file: pkg['main']
     },
     {
       format: 'es',
-      dest: pkg['jsnext:main']
+      file: pkg['jsnext:main']
     }
   ]
 };

--- a/test/test.js
+++ b/test/test.js
@@ -15,66 +15,73 @@ function doesNotInclude(string, substring) {
 }
 
 function makeBundle(entries) {
-  return rollup({ entry: entries, plugins: [multiEntry()] });
+  return rollup({ input: entries, plugins: [multiEntry()] });
 }
 
 describe('rollup-plugin-multi-entry', () => {
-  it('takes a single file as input', () =>
-    makeBundle('test/fixtures/0.js').then(bundle => {
-      const code = bundle.generate({ format: 'cjs' }).code;
-      includes(code, 'exports.zero = zero;');
+  it('takes a single file as input', () => {
+    return makeBundle('test/fixtures/0.js').then(bundle => {
+      return bundle.generate({ format: 'cjs' }).then(({code}) => {
+        includes(code, 'exports.zero = zero;');
+      });
     })
-  );
+  });
 
-  it('takes an array of files as input', () =>
-    makeBundle(['test/fixtures/0.js', 'test/fixtures/1.js']).then(bundle => {
-      const code = bundle.generate({ format: 'cjs' }).code;
-      includes(code, 'exports.zero = zero;');
-      includes(code, 'exports.one = one;');
+  it('takes an array of files as input', () => {
+    return makeBundle(['test/fixtures/0.js', 'test/fixtures/1.js']).then(bundle => {
+      return bundle.generate({ format: 'cjs' }).then(({code}) => {
+        includes(code, 'exports.zero = zero;');
+        includes(code, 'exports.one = one;');
+      });
     })
-  );
+  });
 
-  it('allows an empty array as input', () =>
-    makeBundle([]).then(bundle => {
-      const code = bundle.generate({ format: 'cjs' }).code;
-      doesNotInclude(code, 'exports');
+  it('allows an empty array as input', () => {
+    return makeBundle([]).then(bundle => {
+      return bundle.generate({ format: 'cjs' }).then(({code}) => {
+        doesNotInclude(code, 'exports');
+      });
     })
-  );
+  });
 
-  it('takes a glob as input', () =>
-    makeBundle('test/fixtures/{0,1}.js').then(bundle => {
-      const code = bundle.generate({ format: 'cjs' }).code;
-      includes(code, 'exports.zero = zero;');
-      includes(code, 'exports.one = one;');
+  it('takes a glob as input', () => {
+    return makeBundle('test/fixtures/{0,1}.js').then(bundle => {
+      return bundle.generate({ format: 'cjs' }).then(({code}) => {
+        includes(code, 'exports.zero = zero;');
+        includes(code, 'exports.one = one;');
+      });
     })
-  );
+  });
 
-  it('takes an array of globs as input', () =>
-    makeBundle(['test/fixtures/{0,}.js', 'test/fixtures/{1,}.js']).then(bundle => {
-      const code = bundle.generate({ format: 'cjs' }).code;
-      includes(code, 'exports.zero = zero;');
-      includes(code, 'exports.one = one;');
+  it('takes an array of globs as input', () => {
+    return makeBundle(['test/fixtures/{0,}.js', 'test/fixtures/{1,}.js']).then(bundle => {
+      return bundle.generate({ format: 'cjs' }).then(({code}) => {
+        includes(code, 'exports.zero = zero;');
+        includes(code, 'exports.one = one;');
+      });
     })
-  );
+  });
 
-  it('takes an {include,exclude} object as input', () =>
-    makeBundle(
+  it('takes an {include,exclude} object as input', () => {
+    return makeBundle(
       { include: ['test/fixtures/*.js'], exclude: ['test/fixtures/1.js'] }
     ).then(bundle => {
-      const code = bundle.generate({ format: 'cjs' }).code;
-      includes(code, 'exports.zero = zero;');
-      doesNotInclude(code, 'exports.one = one;');
+      return bundle.generate({ format: 'cjs' }).then(({code}) => {
+        includes(code, 'exports.zero = zero;');
+        doesNotInclude(code, 'exports.one = one;');
+      });
     })
-  );
+  });
 
-  it('allows to prevent exporting', () =>
-    makeBundle(
+  it('allows to prevent exporting', () => {
+    return makeBundle(
       { include: ['test/fixtures/*.js'], exports: false }
     ).then(bundle => {
-      const code = bundle.generate({ format: 'iife' }).code;
-      includes(code, `console.log('Hello, 2');`)
-      doesNotInclude(code, 'zero');
-      doesNotInclude(code, 'one');
+      return bundle.generate({ format: 'cjs' }).then(({code}) => {
+        includes(code, `console.log('Hello, 2');`)
+        doesNotInclude(code, 'zero');
+        doesNotInclude(code, 'one');
+      });
     })
-  );
+  });
 });


### PR DESCRIPTION
This updates rollup-plugin-multi-entry to mangle the `input` option, since `entry` is gone, and also updates the test to reflect the fact that `bundle.generate` now returns a promise.