### PR TITLE
Added a hint that default exports are not exported

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+
+
 # rollup-plugin-multi-entry
 
 Use multiple entry points in your [rollup](https://github.com/rollup/rollup)
@@ -17,6 +19,8 @@ export const c = 3;
 
 Using all three files above as entry points will yield a bundle with exports for
 `a`, `b`, and `c`.
+
+*Notice*: Default exports like `export default class Foo{...}` will not be exported, only named exports are allowed.
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-
-
 # rollup-plugin-multi-entry
 
 Use multiple entry points in your [rollup](https://github.com/rollup/rollup)
@@ -20,7 +18,7 @@ export const c = 3;
 Using all three files above as entry points will yield a bundle with exports for
 `a`, `b`, and `c`.
 
-*Notice*: Default exports like `export default class Foo{...}` will not be exported, only named exports are allowed.
+> *Note*: Default exports like `export default class Foo {...}` will not be exported, only named exports are allowed.
 
 ## Install
 


### PR DESCRIPTION
I was wondering why I didn't find any exports using export-Format `es` and your plugin until I noticed that default export don't seem to work when more then one export is in one file. So I thought it might be helpfull to mention that in the readme.
  